### PR TITLE
fix: Add executable permission to the shell scripts

### DIFF
--- a/services/greeter/client/Dockerfile
+++ b/services/greeter/client/Dockerfile
@@ -1,3 +1,4 @@
 FROM public.ecr.aws/hashicorp/consul:1.9.1
 ADD init.sh /test/init.sh
+RUN chmod +x /test/init.sh
 ENTRYPOINT ["/test/init.sh"]

--- a/services/greeting/client/Dockerfile
+++ b/services/greeting/client/Dockerfile
@@ -1,3 +1,4 @@
 FROM public.ecr.aws/hashicorp/consul:1.9.1
 ADD init.sh /test/init.sh
+RUN chmod +x /test/init.sh
 ENTRYPOINT ["/test/init.sh"]

--- a/services/name/client/Dockerfile
+++ b/services/name/client/Dockerfile
@@ -1,3 +1,4 @@
 FROM public.ecr.aws/hashicorp/consul:1.9.1
 ADD init.sh /test/init.sh
+RUN chmod +x /test/init.sh
 ENTRYPOINT ["/test/init.sh"]


### PR DESCRIPTION
*Description of changes:*
This PR fix the issue for executable permissions on shell scrip i.e. init.sh

By submitting this pull request, I confirm that your docker file can access the init.sh file.
