### PR TITLE
(fix) Remove "EnvironmentOutputProps" from Step 1

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -43,8 +43,6 @@ import * as ec2 from "@aws-cdk/aws-ec2";
 import { EnvironmentInputProps } from './shared-props';
 
 export class Environment extends cdk.Stack {
-  public readonly props: EnvironmentOutputProps;
-
   constructor(scope: cdk.Construct, id: string, inputProps: EnvironmentInputProps) {
     super(scope, id, inputProps);
     


### PR DESCRIPTION
The parameter `EnvironmentOutputProps` causes a compilation error, and is only available after Step 1.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
